### PR TITLE
Prevent failure when no changes to stack

### DIFF
--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -68,4 +68,5 @@ jobs:
             --parameter-overrides \
               'ParameterKey=Name,ParameterValue=example \
               ParameterKey=Version,ParameterValue=${{ steps.vars.outputs.version }}' \
-            --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
+            --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset


### PR DESCRIPTION
**Issue Number:** #10

**Description of Changes:**

As suggested in the issue noted above, `sam deploy` provides an extra arg called `--no-fail-on-empty-changeset` which stops it returning a non-zero exit code when there is nothing to do. This PR adds this argument in to the template/example here which would resolve the issue.

See also the SAM CLI documentation: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-deploy.html

Not a complicated change (surprised someone else hadn't already submitted a PR?). I've done a run-through locally and the arguments all seem to interact with each other OK.

In my mind, this seems like a sensible parameter to include here as we are dealing with CI/CD, not guided deployments.

(Note that we could potentially also add in `--no-confirm-changeset ` which I've used before in my projects as well.)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._