### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -42,9 +42,9 @@ jobs:
           ENVIRONMENT=$BRANCH-$REPOSITORY-${{ secrets.AWS_REGION }}
           # In this step we are setting variables and persistenting them
           # into the environment so that they can be utilized in other steps
-          echo "::set-output name=branch::$BRANCH"
-          echo "::set-output name=repository::$REPOSITORY"
-          echo "::set-output name=environment::$ENVIRONMENT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "repository=$REPOSITORY" >> "$GITHUB_OUTPUT"
+          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
           # Output variables to ensure their values are set correctly when ran
           echo "The region is ${{ secrets.AWS_REGION }}"
           echo "The repository is $REPOSITORY"

--- a/.github/workflows/secondary.yml
+++ b/.github/workflows/secondary.yml
@@ -42,9 +42,9 @@ jobs:
           REGION=$(cat ./config.json | jq -r .region)
           ENVIRONMENT=`echo $REPO | tr "/" "-"`
           BUCKET_NAME=$BRANCH-$ENVIRONMENT
-          echo "::set-output name=environment::$ENVIRONMENT"
-          echo "::set-output name=region::$REGION"
-          echo "::set-output name=bucket_name::$BUCKET_NAME"
+          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
+          echo "region=$REGION" >> "$GITHUB_OUTPUT"
+          echo "bucket_name=$BUCKET_NAME" >> "$GITHUB_OUTPUT"
           echo "The environment is $ENVIRONMENT"
           echo "The region is $REGION"
           echo "The bucket_name is $BUCKET_NAME"


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter